### PR TITLE
⭐ Only include necessary files for the final package.zip

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,19 +23,16 @@ runs:
       shell: bash
       run: sudo apt-get install -y jq
 
-    - name: Remove .files
-      shell: bash
-      run: |
-        rm -rf .git
-        rm -rf .github
-
     - name: Zip repository
       shell: bash
       env:
         PACKAGE_NAME: ${{ inputs.package_name }}
       run: |
         mkdir $PACKAGE_NAME
-        mv * $PACKAGE_NAME || true
+        cp Package.toml $PACKAGE_NAME/
+        cp -r Client $PACKAGE_NAME/
+        cp -r Server $PACKAGE_NAME/
+        cp -r Shared $PACKAGE_NAME/
         zip -r main.zip $PACKAGE_NAME
 
     - name: Request upload URL

--- a/action.yml
+++ b/action.yml
@@ -1,17 +1,20 @@
-name: 'Deploy Helix Package'
-description: 'Builds and publishes a new version of a HELIX Package'
+name: "Deploy Helix Package"
+description: "Builds and publishes a new version of a HELIX Package"
+
 inputs:
   access_token:
-    description: 'Access token for authentication. Can be generated on the HELIX Hub: Account -> Access Tokens'
+    description: "Access token for authentication. Can be generated on the HELIX Hub: Account -> Access Tokens"
     required: true
     type: string
   package_name:
-    description: 'Name of the package to upload. Make sure you have already created this package in the HELIX Hub or Studio'
+    description: "Name of the package to upload. Make sure you have already created this package in the HELIX Hub or Studio"
     required: true
     type: string
+
 outputs: {}
+
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Checkout repository
       uses: actions/checkout@v2


### PR DESCRIPTION
When there are files in a repo that uses this Action which it deems invalid, it spews errors such as this:

![image](https://github.com/user-attachments/assets/8b95ae00-34ab-4c4d-a910-c21429c4e4b7)

To address, instead of trying to remove un-needed files, we only include files that we know are important:
- Package.toml
- Client/
- Server/
- Shared/